### PR TITLE
Refactor Code

### DIFF
--- a/Queryable/Queryable.xcodeproj/project.pbxproj
+++ b/Queryable/Queryable.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		94E917DF2A5A47A300324937 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94E917D72A5A47A300324937 /* Localizable.strings */; };
 		94E917E02A5A47A300324937 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 94E917DA2A5A47A300324937 /* Localizable.strings */; };
 		94ECA38F2A5D52060066F64B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 94ECA38E2A5D52050066F64B /* Assets.xcassets */; };
+		DE4D625A2AECD3CF007AB439 /* FeedbackItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4D62592AECD3CF007AB439 /* FeedbackItemView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +105,7 @@
 		94E917D82A5A47A300324937 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = Localizable.strings; sourceTree = "<group>"; };
 		94E917DB2A5A47A300324937 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = Localizable.strings; sourceTree = "<group>"; };
 		94ECA38E2A5D52050066F64B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DE4D62592AECD3CF007AB439 /* FeedbackItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackItemView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -260,6 +262,7 @@
 			isa = PBXGroup;
 			children = (
 				94E917AC2A5A475B00324937 /* ConfigView.swift */,
+				DE4D62592AECD3CF007AB439 /* FeedbackItemView.swift */,
 				94E917AD2A5A475B00324937 /* EmailHelper.swift */,
 			);
 			path = ConfigPageViews;
@@ -475,6 +478,7 @@
 				94E917C82A5A475B00324937 /* SearchResultsView.swift in Sources */,
 				94E917C42A5A475B00324937 /* PhotoViewForMac.swift in Sources */,
 				94E917B32A5A475B00324937 /* BPETokenizer.swift in Sources */,
+				DE4D625A2AECD3CF007AB439 /* FeedbackItemView.swift in Sources */,
 				94E917B12A5A475B00324937 /* TextEncoder.swift in Sources */,
 				94E9174B2A5A45C000324937 /* QueryableApp.swift in Sources */,
 				94E917CA2A5A475B00324937 /* EmailHelper.swift in Sources */,

--- a/Queryable/Queryable/View/BuildIndexView.swift
+++ b/Queryable/Queryable/View/BuildIndexView.swift
@@ -13,16 +13,15 @@ struct BuildIndexView: View {
 
     var body: some View {
         switch photoSearcher.buildIndexCode {
-        case BUILD_INDEX_CODE.DEFAULT.rawValue:
+        case .DEFAULT:
             Text("")
-        case BUILD_INDEX_CODE.LOADING_PHOTOS.rawValue:
+        case .LOADING_PHOTOS:
             ProgressView() {
                 Text("Loading Photos...")
             }
-        case BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue:
+        case .PHOTOS_LOADED:
             StartBuildView(photoSearcher: photoSearcher)
-            
-        case BUILD_INDEX_CODE.LOADING_MODEL.rawValue:
+        case .LOADING_MODEL:
             ProgressView() {
                 Text("Loading Model...")
             }
@@ -31,7 +30,7 @@ struct BuildIndexView: View {
                     await photoSearcher.loadImageIncoder()
                 }
             }
-        case BUILD_INDEX_CODE.IS_BUILDING_INDEX.rawValue:
+        case .IS_BUILDING_INDEX:
             BuildingIndexView(photoSearcher: photoSearcher)
                 .onAppear {
                     Task {
@@ -40,13 +39,11 @@ struct BuildIndexView: View {
                         UIApplication.shared.isIdleTimerDisabled = false
                     }
                 }
-        case BUILD_INDEX_CODE.BUILD_FINISHED.rawValue:
+        case .BUILD_FINISHED:
             BuildFinishView(photoSearcher: photoSearcher)
         default:
             Text("")
-            
         }
-        
     }
 }
 
@@ -89,9 +86,9 @@ struct StartBuildView: View {
             .accessibilityHint("Press button to build index for all your photos, this may takes a few minutes, depending on the number of your unindexed photos")
             .onTapGesture {
                 if photoSearcher.totalUnIndexedPhotosNum > 0 {
-                    photoSearcher.changeState(from: BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue, to: BUILD_INDEX_CODE.LOADING_MODEL.rawValue)
+                    photoSearcher.changeState(from: .PHOTOS_LOADED, to: .LOADING_MODEL)
                 } else {
-                    photoSearcher.changeState(from: BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue, to: BUILD_INDEX_CODE.BUILD_FINISHED.rawValue)
+                    photoSearcher.changeState(from: .PHOTOS_LOADED, to: .BUILD_FINISHED)
                 }
             }
         }

--- a/Queryable/Queryable/View/ConfigPageViews/ConfigView.swift
+++ b/Queryable/Queryable/View/ConfigPageViews/ConfigView.swift
@@ -21,6 +21,7 @@ struct ConfigView: View {
             Form {
                 Section(header: Text("User Guide and Feedback")) {
                     Label("About Queryable", systemImage: "book")
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             withAnimation {
                                 showAboutText.toggle()
@@ -34,6 +35,7 @@ struct ConfigView: View {
 
 
                     Label("Album Privacy Concerns", systemImage: "photo")
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             withAnimation {
                                 showAlbumPrivacyText.toggle()
@@ -46,6 +48,7 @@ struct ConfigView: View {
                     }
                     
                     Label("Display number of results", systemImage: "circle.grid.2x1.right.filled")
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             withAnimation {
                                 showTOPK_SIMSlider.toggle()
@@ -65,6 +68,7 @@ struct ConfigView: View {
                     }
 
                     Label("Crashs & Feedback", systemImage: "ant")
+                        .accessibilityAddTraits(.isButton)
                         .onTapGesture {
                             withAnimation {
                                 showCrashReportText.toggle()
@@ -85,59 +89,11 @@ struct ConfigView: View {
                 }
 
                 Section(header: Text("Feedback")) {
-                    Link(destination: URL(string: NSLocalizedString("https://discord.com/invite/R3wNsqq3v5", comment: "Discord URL"))!, label: {
-                        
-                            HStack {
-                                Image("DiscordIcon")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 36, height: 36)
-                                    .shadow(radius: 2)
-                                
-                                Text("Discord")
-                                    .foregroundColor(.primary)
-                                Text(NSLocalizedString("discord/R3wNsqq3v5", comment: "Discord"))
-                                    .foregroundColor(.gray)
-                            }
-                        })
-                    .foregroundColor(Color.primary)
+                    FeedbackItemView(title: "Discord", subtitle:NSLocalizedString("discord/R3wNsqq3v5", comment: "Discord") , logoIcon: Image("DiscordIcon"), destination: URL(string: NSLocalizedString("https://discord.com/invite/R3wNsqq3v5", comment: "Discord URL"))!)
                     
-                    Link(destination: URL(string: NSLocalizedString("https://twitter.com/immazzystar", comment: "Twitter URL"))!, label: {
-                        
-                            HStack {
-                                Image("TwitterAvatar")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 40, height: 40)
-                                    .clipShape(Circle())
-                                    .overlay(Circle().stroke(Color.gray, lineWidth: 0.3))
-                                
-                                Text("Twitter")
-                                    .foregroundColor(.primary)
-                                Text(NSLocalizedString("twitter.com/immazzystar", comment: "Twitter"))
-                                    .foregroundColor(.gray)
-                            }
-                        })
-                    .foregroundColor(Color.primary)
-                    
-                    Link(destination: URL(string: NSLocalizedString("https://github.com/mazzzystar/Queryable/issues", comment: "Twitter URL"))!, label: {
-                        
-                            HStack {
-                                Image("GitHub")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 40, height: 40)
-                                    .clipShape(Circle())
-                                    .overlay(Circle().stroke(Color.gray, lineWidth: 0.3))
-                                
-                                Text("Github")
-                                    .foregroundColor(.primary)
-                                Text(NSLocalizedString("github/Queryable", comment: "Github"))
-                                    .foregroundColor(.gray)
-                            }
-                        })
-                    .foregroundColor(Color.primary)
-                    
+                    FeedbackItemView(title: "Twitter", subtitle:NSLocalizedString("twitter.com/immazzystar", comment: "Twitter") , logoIcon: Image("TwitterAvatar"), destination: URL(string: NSLocalizedString("https://twitter.com/immazzystar", comment: "Twitter URL"))!)
+
+                    FeedbackItemView(title: "Github", subtitle:NSLocalizedString("github/Queryable", comment: "Github"), logoIcon: Image("GitHub"), destination: URL(string: NSLocalizedString("https://github.com/mazzzystar/Queryable/issues", comment: "Twitter URL"))!)
                 }
                 
                 Section(header: Text("More App by This Developer")) {
@@ -189,8 +145,6 @@ struct ConfigView: View {
                     })
                     .foregroundColor(Color.primary)
                 }
-                    
-
             }
         }.onAppear {
             sliderValue = Double(photoSearcher.TOPK_SIM)

--- a/Queryable/Queryable/View/ConfigPageViews/FeedbackItemView.swift
+++ b/Queryable/Queryable/View/ConfigPageViews/FeedbackItemView.swift
@@ -1,0 +1,39 @@
+//
+//  FeedbackItemView.swift
+//  Queryable
+//
+//  Created by knight on 2023/10/28.
+//
+
+import SwiftUI
+
+struct FeedbackItemView: View {
+    let title: String
+    let subtitle: String
+    let logoIcon: Image
+    let destination: URL
+    
+    var body: some View {
+        Link(destination: destination, label: {
+            HStack {
+                logoIcon
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 36, height: 36)
+                    .clipShape(Circle())
+                    .shadow(radius: 2)
+                Text(title)
+                    .foregroundColor(.primary)
+                Text(subtitle)
+                    .foregroundColor(.gray)
+            }
+        })
+        .foregroundColor(Color.primary)
+    }
+}
+
+struct FeedbackItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        FeedbackItemView(title: "Discord", subtitle:NSLocalizedString("discord/R3wNsqq3v5", comment: "Discord") , logoIcon: Image("DiscordIcon"), destination: URL(string: NSLocalizedString("https://discord.com/invite/R3wNsqq3v5", comment: "Discord URL"))!)
+    }
+}

--- a/Queryable/Queryable/View/ContentView.swift
+++ b/Queryable/Queryable/View/ContentView.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
                             .labelStyle(.iconOnly)
                             .font(.title3)
                             .accessibilityLabel(Text("Config Button"))
-                            .accessibilityHint(Text("About Queryable, privacy concerns and feedback concat"))
+                            .accessibilityHint(Text("About Queryable, privacy concerns and feedback contact"))
                     }
                 }
             }

--- a/Queryable/Queryable/View/SearchBarView.swift
+++ b/Queryable/Queryable/View/SearchBarView.swift
@@ -11,21 +11,16 @@ struct SearchBarView: View {
     @FocusState private var inputFocused: Bool
     @ObservedObject var photoSearcher: PhotoSearcher
     @State var searchText: String = ""
-    private let showString = ["My love", "Dark night room with a lamp", "Snow outside the window", "Deep blue", "Cute kitten", "Photos of our gathering", "Beach, waves, sunset", "In car view, car on the road", "Screen display of traffic info", "Selfie in front of mirror", "Cheers"].randomElement()
+    private let showString: LocalizedStringKey = ["My love", "Dark night room with a lamp", "Snow outside the window", "Deep blue", "Cute kitten", "Photos of our gathering", "Beach, waves, sunset", "In car view, car on the road", "Screen display of traffic info", "Selfie in front of mirror", "Cheers"].randomElement()!
     
     var body: some View {
         HStack {
             Image(systemName: "magnifyingglass")
-                .accessibilityAddTraits(.isImage)
-                .accessibilityHint(Text("An icon, no actual usage"))
-//            TextField("Input here to search Photos", text: $searchText)
-            TextField("\"\(NSLocalizedString(showString ?? "My love", comment: ""))\"", text: $searchText)
-//            TextField("Input text here, e.g. \"We fell in love\"", text: $searchText)
-                .modifier(TextFieldClearButton(photoSearcher: photoSearcher, inputFocused: $inputFocused, text: $searchText))
+                .accessibilityHidden(true)
+            TextField(showString, text: $searchText)
                 .multilineTextAlignment(.leading)
                 .focused($inputFocused)
                 .accessibilityAddTraits(.isSearchField)
-                .accessibilityLabel(Text("Text Field"))
                 .accessibilityHint(Text("Input your sentences here, then press enter"))
                 .onSubmit {
                     print("Searching...")
@@ -34,9 +29,23 @@ struct SearchBarView: View {
                     }
                 }
                 .submitLabel(.search)
+            if !searchText.isEmpty {
+                Button {
+                    self.clearSearch()
+                } label: {
+                    Image(systemName: "delete.left")
+                        .foregroundColor(Color(UIColor.opaqueSeparator))
+                        .accessibilityLabel("Clear search")
+                }
+            }
         }
     }
     
+    private func clearSearch() {
+        self.searchText = ""
+        inputFocused = true
+        photoSearcher.searchResultCode = .MODEL_PREPARED
+    }
 }
 
 

--- a/Queryable/Queryable/View/SearchResultsView.swift
+++ b/Queryable/Queryable/View/SearchResultsView.swift
@@ -211,13 +211,13 @@ struct TipsView: View {
             NavigationLink(destination: BuildIndexView(photoSearcher: photoSearcher)
                 .onAppear {
                     Task {
-                        photoSearcher.buildIndexCode = BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue
+                        photoSearcher.buildIndexCode = .PHOTOS_LOADED
                         await photoSearcher.fetchPhotos()
-                        photoSearcher.buildIndexCode = BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue
+                        photoSearcher.buildIndexCode = .PHOTOS_LOADED
                     }
                 }
                 .onDisappear {
-                    photoSearcher.buildIndexCode = BUILD_INDEX_CODE.DEFAULT.rawValue
+                    photoSearcher.buildIndexCode = .DEFAULT
                 }
             ) {
                 HStack {

--- a/Queryable/Queryable/ViewModel/PhotoSearcher.swift
+++ b/Queryable/Queryable/ViewModel/PhotoSearcher.swift
@@ -42,7 +42,7 @@ class PhotoSearcher: ObservableObject {
     
     // -3: default, -2: Is searching now, -1: Never indexed. 0: No result. 1: Has result.
     @Published var searchResultCode: SEARCH_RESULT_CODE = .DEFAULT
-    @Published var buildIndexCode: Int = BUILD_INDEX_CODE.DEFAULT.rawValue
+    @Published var buildIndexCode: BUILD_INDEX_CODE = .DEFAULT
     @Published var totalUnIndexedPhotosNum: Int = -1
     @Published var curIndexingNums: Int = -1
     @Published var curShowingPhoto: UIImage = UIImage(systemName: "photo")!
@@ -77,7 +77,7 @@ class PhotoSearcher: ObservableObject {
         self.TOPK_SIM = defaultTOPK_SIM
     }
     
-    func changeState(from statusCode1: Int, to statusCode2: Int) {
+    func changeState(from statusCode1: BUILD_INDEX_CODE, to statusCode2: BUILD_INDEX_CODE) {
         if self.buildIndexCode == statusCode1 {
             self.buildIndexCode = statusCode2
         }
@@ -117,7 +117,7 @@ class PhotoSearcher: ObservableObject {
     }
     
     func fetchPhotos() async {
-        self.buildIndexCode = BUILD_INDEX_CODE.LOADING_PHOTOS.rawValue
+        self.buildIndexCode = .LOADING_PHOTOS
         
         // set network authorization
         await self.photoCollection.cache.requestOptions.isNetworkAccessAllowed = false
@@ -145,13 +145,13 @@ class PhotoSearcher: ObservableObject {
             }
             
             if self.totalPhotosNum > 0 {
-                self.buildIndexCode = BUILD_INDEX_CODE.PHOTOS_LOADED.rawValue
+                self.buildIndexCode = .PHOTOS_LOADED
             }
         }
     }
     
     func loadImageIncoder() async {
-        self.buildIndexCode = BUILD_INDEX_CODE.LOADING_MODEL.rawValue
+        self.buildIndexCode = .LOADING_MODEL
         guard let path = Bundle.main.path(forResource: "CoreMLModels", ofType: nil, inDirectory: nil) else {
             fatalError("Fatal error: failed to find the CoreML models.")
         }
@@ -164,12 +164,11 @@ class PhotoSearcher: ObservableObject {
                 // 8.542439937591553 seconds used for loading img encoder
                 print("\(startingTime.timeIntervalSinceNow * -1) seconds used for loading img encoder")
                 self.imageEncoder = imgEncoder
-                self.buildIndexCode = BUILD_INDEX_CODE.MODEL_LOADED.rawValue
-                self.buildIndexCode = BUILD_INDEX_CODE.IS_BUILDING_INDEX.rawValue
+                self.buildIndexCode = .MODEL_LOADED
+                self.buildIndexCode = .IS_BUILDING_INDEX
             } catch let error {
                 logger.error("Failed to load model: \(error.localizedDescription)")
             }
-            
         }
     }
     
@@ -376,7 +375,7 @@ class PhotoSearcher: ObservableObject {
         // delete large memory usage
         self.buildingEmbedding = [String: MLMultiArray]()
         self.imageEncoder = nil
-        self.buildIndexCode = BUILD_INDEX_CODE.BUILD_FINISHED.rawValue
+        self.buildIndexCode = .BUILD_FINISHED
         self.totalUnIndexedPhotosNum = 0
         
         clearCache()


### PR DESCRIPTION
1. Use enum in swifty way
2. Config View (User guide and feedback add isButton trait)
3. Extract FeedbackItemView to reduce duplicate code
4. Refactor Searchbar
 - Cancel modifier TextFieldClearButton, we don't reuse it but has more complexity code structure.
 - Additional gain of this code is in a11y, we can show `clear search` button correctly.